### PR TITLE
expose API to allow clients to get single TODO items by Id.

### DIFF
--- a/src/controllers/todo-controller.ts
+++ b/src/controllers/todo-controller.ts
@@ -12,7 +12,8 @@ import {
     ValidationFailure,
 } from '@typings';
 import {
-    createTodoValidator
+    createTodoValidator,
+    getTodoValidator
 } from '@validators';
 
 export class TodoController extends BaseController {
@@ -27,6 +28,7 @@ export class TodoController extends BaseController {
 
     private initializeRoutes() {
         this.router.post (`${this.basePath}`, createTodoValidator (this.appContext), this.createTodo);
+        this.router.get (`${this.basePath}/:id`, getTodoValidator (this.appContext), this.getTodo);
     }
 
     private createTodo = async (
@@ -49,5 +51,24 @@ export class TodoController extends BaseController {
         return res.status(201).json(todo.serialize());
     }
 
+    private getTodo = async (
+        req: ExtendedRequest,
+        res: Response,
+        next: NextFunction
+    ) => {
 
+        const failures: ValidationFailure [] = Validation.extractValidationErrors (
+            req,
+        );
+        if (failures.length > 0) {
+            const valError = new Errors.ValidationError (
+                res.__('DEFAULT_ERRORS.VALIDATION_FAILED'),
+                failures
+            );
+            return next (valError);
+        }
+        const _id = req.params.id;
+        const todo = await this.appContext.todoRepository.findOne ({ _id });
+        return res.status (200).json (todo.serialize ());
+    }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -13,7 +13,8 @@
     "PASSWORD_MISSING": "Please provide a password.",
     "DUPLICATE_EMAIL": "The email you provided is already taken. Please provide a different one.",
     "INVALID_TITLE_VALUE": "Please provide the title of the task.",
-    "DUPLICATE_TASK": "Please provide a different title for the task to be created."
+    "DUPLICATE_TASK": "Please provide a different title for the task to be created.",
+    "INVALID_TASK_ID": "Please provide a correct Id of the task in the request parameter."
   },
   "MESSAGES": {
     "HEALTHCHECK": "OK"

--- a/src/validators/get-todo-validator.ts
+++ b/src/validators/get-todo-validator.ts
@@ -1,0 +1,16 @@
+
+
+import lodash from 'lodash';
+import { check, ValidationChain } from 'express-validator';
+import { AppContext } from '@typings';
+import mongoose from 'mongoose';
+
+/** making use of mongoose to validate ID given by the user */
+
+const getTodoValidator = (appContext: AppContext): ValidationChain [] => [
+    check ('id', 'VALIDATION_ERRORS.INVALID_TASK_ID').custom ((id) => {
+        return mongoose.Types.ObjectId.isValid (id);
+    })
+]
+
+export default getTodoValidator;

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -1,5 +1,6 @@
 import createAccessTokenValidator from './create-access-token-validator';
 import createAccountValidator from './create-account-validator';
 import createTodoValidator from './create-todo-validator';
+import getTodoValidator from './get-todo-validator';
 
-export { createAccessTokenValidator, createAccountValidator, createTodoValidator };
+export { createAccessTokenValidator, createAccountValidator, createTodoValidator, getTodoValidator };

--- a/test/spec/todo/todo.spec.ts
+++ b/test/spec/todo/todo.spec.ts
@@ -13,6 +13,7 @@ import { respositoryContext, testAppContext } from '../../mocks/app-context';
 import { AuthHelper } from '@helpers';
 import { App } from '@server';
 import { Todo } from '@models';
+import _ from 'lodash';
 
 chai.use(chaiHttp);
 const expect = chai.expect;
@@ -90,6 +91,70 @@ describe ('POST /todo',() => {
     // There should be only 1 task in Database having title 'test title'
     todo = await testAppContext.todoRepository.getAll ({ title });
     expect (todo).to.have.lengthOf (1);
+
+  })
+
+})
+
+
+describe ('GET/:id', () => {
+
+  let _id = '618bbaf32d17c54823853200';
+  let todo;
+
+  it ('should return a task if exists with the provided task id in request params', async () => {
+
+    // Precondition
+    // There should be a task already in DB with the id = '618bbaf32d17c54823853200';
+    todo = await testAppContext.todoRepository.findOne ({ _id });
+    if (_.isEmpty (todo)) {
+      todo = await testAppContext.todoRepository.save (new Todo ({ _id, title: 'test title' }));
+    }
+
+    // Perform Testing
+    // Trying to get task with the id = '618bbaf32d17c54823853200'
+
+    const res = await chai.request (expressApp).get (`/todo/${_id}`);
+    expect (res).to.have.status (200);
+    expect (res.body).to.have.property ('id');
+    expect (res.body).to.have.property ('title');
+
+    // Postcondition
+    // Task should still be in the database without any change
+    todo = await testAppContext.todoRepository.findOne ({ _id });
+    expect (todo).to.have.property ('_id');
+    expect (todo).to.have.property ('title');
+
+  });
+
+  it ('should return an empty object, if no task exists with task "id" specified', async () => {
+
+    // Precondition
+    // Task with _id should not exists in the database
+    todo = await testAppContext.todoRepository.findOne ({ _id });
+    if (!_.isEmpty (todo)) {
+      await testAppContext.todoRepository.deleteMany ({ _id });
+    }
+
+    // Perform Testing
+    // Trying to get task with ID = '618bbaf32d17c54823853200', which is already been deleted
+    const res = await chai.request (expressApp).get (`/todo/${_id}`);
+    expect (res).to.have.status (200);
+    expect (JSON.stringify (res.body)).to.equal ('{}');
+
+    // Postcondition
+    // Task with ID = '618bbaf32d17c54823853200' should not exist in database.
+    todo = await testAppContext.todoRepository.findOne ({ _id });
+    expect (JSON.stringify (todo)).to.equal ('{}');
+
+  })
+
+  it ('should return validation error if "id" specified in the request params is not of proper format', async () => {
+
+    // Perform Testing
+    // should get validation error, if try to get task having id which is not a proper mongoose ID.
+    const res = await chai.request (expressApp).get (`/todo/thisisinvalididoftask`);
+    expect (res).to.have.status (400);
 
   })
 


### PR DESCRIPTION
## Description
expose API to allow clients to get single TODO items by Id.

## Database schema changes
N/A

## Tests
### Automated test cases added
1. GET /todo/:id endpoint should return an empty object if no task exists with the "id" specified in request params, should return 200 response code.
2. GET /todo/:id endpoint should return a task object if task exists with the "id" specified in the request params, should return 200 response code.
3. GET /todo/:id endpoint should return a validation error, if "id" specified in request params is not an appropriate mongoose ObjectId.

### Manual test cases run 
1. URL: /todo/618c978b753dda2e662748db
    Method: GET
    ResponseBody: {}
    ResponseCode: 200

2. URL: /todo/618c978b753dda2e662748da
    Method: GET
    ResponseBody: {
      "id": "618c978b753dda2e662748da",
      "title": "first task"
    }
    ResponseCode: 200

3. URL: /todo/thisisinvalidtaskid
    Method: GET
    ResponseBody: {
    "message": "Validation failed. Please modify the request and try again.",
    "failures": [
        {
            "field": "id",
            "message": "Please provide a correct Id of the task in the request parameter."
        }
     ]
}
ResponseCode: 400