### PR TITLE
Feature/delete-todo

### DIFF
--- a/src/controllers/todo-controller.ts
+++ b/src/controllers/todo-controller.ts
@@ -16,38 +16,64 @@ import {
 } from '@validators';
 
 export class TodoController extends BaseController {
-    
-    public basePath: string = '/todo';
-    public router: Router = Router ();
+  public basePath: string = '/todo';
+  public router: Router = Router ();
 
-    constructor(ctx: AppContext) {
-        super(ctx);
-        this.initializeRoutes();
-    }
+  constructor(ctx: AppContext) {
+      super(ctx);
+      this.initializeRoutes();
+  }
 
-    private initializeRoutes() {
-        this.router.post (`${this.basePath}`, createTodoValidator (this.appContext), this.createTodo);
-    }
+  private initializeRoutes() {
+      this.router.post (`${this.basePath}`, createTodoValidator (this.appContext), this.createTodo);
+      this.router.delete (`${this.basePath}/:id`, this.deleteTodo);
+  }
 
-    private createTodo = async (
-        req: ExtendedRequest,
-        res: Response,
-        next: NextFunction,
-    ) => {
-        const failures: ValidationFailure[] = Validation.extractValidationErrors(
-            req,
+  private createTodo = async (
+      req: ExtendedRequest,
+      res: Response,
+      next: NextFunction,
+  ) => {
+      const failures: ValidationFailure[] = Validation.extractValidationErrors(
+          req,
+      );
+      if (failures.length > 0) {
+          const valError = new Errors.ValidationError(
+              res.__('DEFAULT_ERRORS.VALIDATION_FAILED'),
+              failures,
+          );
+          return next(valError);
+      }
+      const { title } = req.body;
+      const todo = await this.appContext.todoRepository.save(new Todo ({ title }) );
+      return res.status(201).json(todo.serialize());
+  }
+
+  private deleteTodo = async (
+      req: ExtendedRequest,
+      res: Response,
+      next: NextFunction
+  ) => {
+
+    try {
+      
+      const failures: ValidationFailure [] = Validation.extractValidationErrors (
+        req,
+      );
+      if (failures.length > 0) {
+        const valError = new Errors.ValidationError (
+            res.__('DEFAULT_ERRORS.VALIDATION_FAILED'),
+            failures
         );
-        if (failures.length > 0) {
-            const valError = new Errors.ValidationError(
-                res.__('DEFAULT_ERRORS.VALIDATION_FAILED'),
-                failures,
-            );
-            return next(valError);
-        }
-        const { title } = req.body;
-        const todo = await this.appContext.todoRepository.save(new Todo ({ title }) );
-        return res.status(201).json(todo.serialize());
+        return next (valError);
+      }
+      const _id = req.params.id;
+      const deletedTodo = await this.appContext.todoRepository.deleteMany ({ _id });
+      return res.status (204).json (deletedTodo);
+
+    } catch (error) {
+      return next (error);
     }
 
-
+  }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -13,7 +13,8 @@
     "PASSWORD_MISSING": "Please provide a password.",
     "DUPLICATE_EMAIL": "The email you provided is already taken. Please provide a different one.",
     "INVALID_TITLE_VALUE": "Please provide the title of the task.",
-    "DUPLICATE_TASK": "Please provide a different title for the task to be created."
+    "DUPLICATE_TASK": "Please provide a different title for the task to be created.",
+    "INVALID_ID": "The passed id is not a valid mongoose ObjectId, please provide a valid mongoose ObjectId."
   },
   "MESSAGES": {
     "HEALTHCHECK": "OK"

--- a/src/storage/data-store.ts
+++ b/src/storage/data-store.ts
@@ -6,4 +6,8 @@ export interface IDataStore extends Reader, Writer {
    * convert id string to object id
    */
   toObjectId: (id: string) => any;
+  /**
+   * validate if the string is a valid mongooseId
+   */
+  isValidId: (id: string) => boolean;
 }

--- a/src/storage/mongoose/mongo-store.ts
+++ b/src/storage/mongoose/mongo-store.ts
@@ -187,18 +187,17 @@ export class MongoStore implements IDataStore {
     modelFactory?: ModelFactory<T>,
   ): Promise<DeleteResult> {
 
-    if (filter._id && !Types.ObjectId.isValid (filter._id)) {
-      return new Promise ((resolve, reject) => {
-        reject (new Error (`Unprocessable Entity in _id`));
-      })
-    }
-
     return this.getModel<T>(modelFactory)
       .deleteMany(filter)
       .exec()
       .then((result) => {
         return { success: true, deletedCount: result.deletedCount };
       });
+  }
+
+  /** method to check if an Id is a valid mongoose Id or not */
+  public isValidId (id: string): boolean {
+    return Types.ObjectId.isValid (id);
   }
 
   /** 

--- a/src/storage/mongoose/mongo-store.ts
+++ b/src/storage/mongoose/mongo-store.ts
@@ -186,6 +186,13 @@ export class MongoStore implements IDataStore {
     filter: LooseObject,
     modelFactory?: ModelFactory<T>,
   ): Promise<DeleteResult> {
+
+    if (filter._id && !Types.ObjectId.isValid (filter._id)) {
+      return new Promise ((resolve, reject) => {
+        reject (new Error (`Unprocessable Entity in _id`));
+      })
+    }
+
     return this.getModel<T>(modelFactory)
       .deleteMany(filter)
       .exec()
@@ -199,7 +206,7 @@ export class MongoStore implements IDataStore {
    * the getType is returning Model functions and has a return type of any
    */
 
-  private getModel<T extends BaseModel>(
+   private getModel<T extends BaseModel>(
     modelFactory: ModelFactory<T>,
   ): MongoosModel<Document> {
     if (modelFactory.getType () === Account) {

--- a/src/storage/repositories/base-repository.ts
+++ b/src/storage/repositories/base-repository.ts
@@ -45,6 +45,10 @@ export class BaseRepository<T> {
   public deleteMany(filter: LooseObject): Promise<DeleteResult> {
     return this.context.store.deleteMany(filter, this.modelFactory());
   }
+  
+  public isValidId (id: string) {
+    return this.context.store.isValidId (id);
+  }
 
   protected modelFactory(): ModelFactory<T> {
     throw new Error('Not Implemented');

--- a/src/validators/delete-todo-validator.ts
+++ b/src/validators/delete-todo-validator.ts
@@ -1,0 +1,12 @@
+
+import lodash from 'lodash';
+import { check, ValidationChain } from 'express-validator';
+import { AppContext } from '@typings';
+
+const deleteTodoValidator = (appContext: AppContext): ValidationChain[] => [
+  check ('id', 'VALIDATION_ERRORS.INVALID_ID').custom ((id) => {
+    return appContext.todoRepository.isValidId (id);
+  })
+]
+
+export default deleteTodoValidator;

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -1,5 +1,6 @@
 import createAccessTokenValidator from './create-access-token-validator';
 import createAccountValidator from './create-account-validator';
 import createTodoValidator from './create-todo-validator';
+import deleteTodoValidator from './delete-todo-validator';
 
-export { createAccessTokenValidator, createAccountValidator, createTodoValidator };
+export { createAccessTokenValidator, createAccountValidator, createTodoValidator, deleteTodoValidator };

--- a/test/spec/todo/todo.spec.ts
+++ b/test/spec/todo/todo.spec.ts
@@ -120,7 +120,7 @@ describe ('DELETE /todo/:id', () => {
     // Perform Testing
     // Trying to delete a task providing invalid task Id
     const res = await chai.request (expressApp).delete (`/todo/itisinvalidid`);
-    expect (res).to.have.status (500);
+    expect (res).to.have.status (400);
   })
 
 })

--- a/test/spec/todo/todo.spec.ts
+++ b/test/spec/todo/todo.spec.ts
@@ -94,3 +94,33 @@ describe ('POST /todo',() => {
   })
 
 })
+
+describe ('DELETE /todo/:id', () => {
+  let title = 'deletion api test';
+  let todo;
+  it ('should delete the task, if task present in the database', async () => {
+    
+    // Precondition Test
+    // There should already be a task present in the database
+    todo = await testAppContext.todoRepository.save (new Todo ({ title }));
+
+    // Perform Testing
+    // Trying to delete the task using task Id
+    const res = await chai.request (expressApp).delete (`/todo/${todo._id}`);
+    expect (res).to.have.status (204);
+
+    // PostCondition Test
+    // The task should not present in DB now
+    todo = await testAppContext.todoRepository.findOne ({ _id:todo._id });
+    expect (JSON.stringify (todo)).to.equal ('{}');
+  })
+  
+  it ('should return a internal server error, if provided an invalid mongoose Object Id', async () => {
+
+    // Perform Testing
+    // Trying to delete a task providing invalid task Id
+    const res = await chai.request (expressApp).delete (`/todo/itisinvalidid`);
+    expect (res).to.have.status (500);
+  })
+
+})


### PR DESCRIPTION
## Description
expose API endpoint to allow clients to delete a todo item by id.

## Database schema changes
N/A

## Tests
### Automated test cases added
1. DELETE /todo/:id should delete a task if task already exists in database, should return 204 response code.
2. DELETE /todo/:id should return a validation error if "id" parameter passed in the request is not a valid mongoose ObjectId.

### Manual test cases run
1. If "Id" parameter is a valid Id then it should delete todo with that Id from database.
    URL: /todo/:id
    Method: DELETE
    ResponseBody: {}
    ResponseCode: 204

2. If "Id" parameter is not a valid id, then it should return a validation Error.
    URL: /todo/:invalid-id
    Method: DELETE
    ResponseBody:{
    "message": "Validation failed. Please modify the request and try again.",
    "failures": [
        {
            "field": "id",
            "message": "The passed id is not a valid mongoose ObjectId, please provide a valid mongoose ObjectId."
        }
    ]
}
    ResponseCode: 400